### PR TITLE
ci: add Dependabot configuration for egg directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "npm"
+    directory: "/egg"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
@@ -23,5 +28,10 @@ updates:
 
   - package-ecosystem: "uv"
     directory: "/bnf"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "uv"
+    directory: "/egg"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Summary
Adds Dependabot configuration for the `egg` directory to automate dependency updates for both `npm` and `uv` ecosystems.

Changes
- Updated `.github/dependabot.yml`:
  - Added `npm` ecosystem check for `/egg`.
  - Added `uv` ecosystem check for `/egg`.