### PR TITLE
ci: include source distributions in PyPI uploads.

### DIFF
--- a/.github/workflows/bnf-pytest.yml
+++ b/.github/workflows/bnf-pytest.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: dist
-          path: bnf/dist/*.whl
+          path: bnf/dist/
 
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/egg-pytest.yml
+++ b/.github/workflows/egg-pytest.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: dist
-          path: egg/dist/*.whl
+          path: egg/dist/
 
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -65,9 +65,34 @@ jobs:
           name: wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
 
+  sdist:
+    runs-on: ubuntu-latest
+    needs: pytest
+
+    if: "github.event_name == 'push' && startsWith(github.ref, 'refs/tags')"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: recovery tag information
+        run: git fetch --tags --force
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ env.PYTHON_LATEST_VERSION }}
+          enable-cache: true
+
+      - name: build sdist
+        run: uv build --sdist
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
   upload:
     runs-on: ubuntu-latest
-    needs: wheels
+    needs: [wheels, sdist]
 
     environment:
       name: pypi
@@ -81,6 +106,11 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: sdist
+          path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Description
This PR updates the GitHub Actions workflows to ensure that source distributions (sdist) are built and uploaded to PyPI alongside the wheels. This allows users to install the packages from source when a compatible wheel is not available for their platform.

Changes:
 - `pytest.yml` (apyds): - Added a new sdist job to build the source distribution using uv build --sdist. - Updated the upload job to wait for and download both wheels and the source distribution before publishing.
 - `bnf-pytest.yml` (apyds-bnf):
     - Updated the artifact upload step to include the entire dist/ directory (containing both .whl and .tar.gz files generated by uv build).
 - `egg-pytest.yml` (apyds-egg): - Updated the artifact upload step to include the entire dist/ directory.